### PR TITLE
Write the customInstrument* script to the same folder as the wrapper script

### DIFF
--- a/CustomizedInstrumentation/customInstrumentWrapper.py
+++ b/CustomizedInstrumentation/customInstrumentWrapper.py
@@ -80,10 +80,10 @@ def main():
         sys.exit(1)
     time.sleep(1)
 
-    with open('customInstrument.py', 'wb') as f:
+    with open(os.path.join(os.path.dirname(__file__), 'customInstrument.py'), 'wb') as f:
         f.write(response.content)
 
-    if os.path.getsize('customInstrument.py') == 0:
+    if os.path.getsize(os.path.join(os.path.dirname(__file__), 'customInstrument.py')) == 0:
         print("Failed to Download Instrumentation Script! (Download Error)")
         sys.exit(1)
 

--- a/CustomizedInstrumentation/customInstrumentWrapperAndroid.py
+++ b/CustomizedInstrumentation/customInstrumentWrapperAndroid.py
@@ -101,10 +101,10 @@ def main():
         sys.exit(1)
     time.sleep(1)
 
-    with open('customInstrumentAndroidD.py', 'wb') as f:
+    with open(os.path.join(os.path.dirname(__file__), 'customInstrumentAndroidD.py'), 'wb') as f:
         f.write(response.content)
 
-    if os.path.getsize('customInstrumentAndroidD.py') == 0:
+    if os.path.getsize(os.path.join(os.path.dirname(__file__), 'customInstrumentAndroidD.py')) == 0:
         print("Failed to Download Instrumentation Script! (Download Error)")
         sys.exit(1)
 


### PR DESCRIPTION
This will resolve the limitation stated in the documentation: 'Important: The path of the shell must be the path of the script.' See: https://help.perfecto.io/perfecto-help/content/perfecto/manual-testing/android_offline_instrumentation.htm#Runtheactivatortool